### PR TITLE
feat: add bigdecimal (.cr) mapping to numeric (pg) in converter and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ end
 #### Column types
 
 - `Number`, `String`, `Time`, `Boolean` and `Jsonb` structures are already mapped.
+- `Numeric` ([arbitrary precision number](https://www.postgresql.org/docs/9.6/datatype-numeric.html)) is also supported
 - `Array` of primitives too.
 For other type of data, just create your own converter !
 

--- a/manual/model/column-types/model-definition.md
+++ b/manual/model/column-types/model-definition.md
@@ -111,6 +111,7 @@ end
 | `Int32` | `int`, `serial` |
 | `Int64` | `bigint`, `bigserial` |
 | `Array(Type)` | `type[]` \(_**note**: type can be of any primitives above_\) |
+| `BigDecimal` | `numeric`|
 | `JSON::Any` | `jsonb` |
 | `Time` | `timestamp without time zone` |
 

--- a/manual/model/column-types/model-definition.md
+++ b/manual/model/column-types/model-definition.md
@@ -115,3 +115,44 @@ end
 | `JSON::Any` | `jsonb` |
 | `Time` | `timestamp without time zone` |
 
+#### Using BigDecimal (in Model) and Numeric (in Migrations)
+`BigDecimal` ([in `.cr`](https://crystal-lang.org/api/0.35.1/BigDecimal.html)) is mapped to `Numeric` ([in `pg`](https://www.postgresql.org/docs/9.6/datatype-numeric.html)) in migration columns (i.e. declaring column data type as `"bigdecimal"` would be equal to the column being declared with type `"numeric"`, if you wish to specify precision, and scale, please use `"numeric(precision, scale)"` or `"numeric(precision)"` (with scale defaulting to 0), instead of `"bigdecimal"`)
+
+Please take note that PostgreSQL will throw a `numeric field overflow` (and in Clear: `Clear::SQl::Error`) if you `INSERT` into the database a BigDecimal/ numeric value with the integer part (to the left of the radix point) of a size that is bigger than the precision that is specified in the numeric type that you declare. This can be seen from the following example taken from specs:
+
+```
+
+  class Data
+    include Clear::Model
+
+    column id : Int32, primary: true, presence: false
+    column num3 : BigDecimal?
+    column num4 : BigDecimal?
+  end
+
+  class ModelSpecMigration123
+    include Clear::Migration
+
+    def change(dir)
+      create_table(:model_spec_data) do |t|
+        t.column "num3", "numeric(9)"
+        t.column "num4", "numeric(8)"
+      end
+    end
+end
+
+data = Data.new
+big_number = BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 40) # this is the same as "-102938719.2083710928371092837019283701982370918237"
+```
+
+The following case would not throw an error
+```
+data.num3 = big_number
+data.save!
+```
+
+However this case would throw an error
+```
+data.num4 = big_number
+data.save!
+```

--- a/spec/model/converter_spec.cr
+++ b/spec/model/converter_spec.cr
@@ -87,4 +87,29 @@ module ConverterSpec
       converter.to_db(nil).should eq(nil)
     end
   end
+  describe "Clear::Model::Converter::BigDecimal" do
+    converter = Clear::Model::Converter::BigDecimalConverter
+
+    it "converts to column" do
+      converter.to_column(BigDecimal.new(42.0123))
+        .should eq(BigDecimal.new(BigInt.new(420123), 4))
+
+      converter.to_column(BigDecimal.new("42_42_42_24.0123_456_789"))
+        .should eq(BigDecimal.new(BigInt.new(424242240123456789), 10))
+
+      converter.to_column(BigDecimal.new("-0.1029387192083710928371092837019283701982370918237"))
+        .should eq(BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 49))
+    end
+
+    it "converts to db" do
+      converter.to_db(BigDecimal.new(42.0123))
+        .should eq(BigDecimal.new(BigInt.new(420123), 4))
+
+      converter.to_db(BigDecimal.new("42_42_42_24.0123_456_789"))
+        .should eq(BigDecimal.new(BigInt.new(424242240123456789), 10))
+
+      converter.to_db(BigDecimal.new("-0.1029387192083710928371092837019283701982370918237"))
+        .should eq(BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 49))
+    end
+  end
 end

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -180,10 +180,10 @@ module ModelSpec
       end
 
       create_table(:model_spec_data) do |t|
-        t.column :num1, "numeric", index: true
-        t.column :num2, "numeric(18, 8)"
-        t.column :num3, "numeric(9)"
-        t.column :num4, "numeric(8)"
+        t.column "num1", "bigdecimal", index: true
+        t.column "num2", "numeric(18, 8)"
+        t.column "num3", "numeric(9)"
+        t.column "num4", "numeric(8)"
 
         t.timestamps
       end

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -106,6 +106,16 @@ module ModelSpec
     self.table = "model_users"
   end
 
+  class Data
+    include Clear::Model
+
+    column id : Int32, primary: true, presence: false
+    column num1 : BigDecimal?
+    column num2 : BigDecimal?
+    column num3 : BigDecimal?
+    column num4 : BigDecimal?
+  end
+
   class ModelWithUUID
     include Clear::Model
 
@@ -167,6 +177,15 @@ module ModelSpec
       end
 
       create_table("model_with_uuid", id: :uuid) do |_|
+      end
+
+      create_table(:model_spec_data) do |t|
+        t.column :num1, "numeric", index: true
+        t.column :num2, "numeric(18, 8)"
+        t.column :num3, "numeric(9)"
+        t.column :num4, "numeric(8)"
+
+        t.timestamps
       end
     end
   end
@@ -374,7 +393,7 @@ module ModelSpec
           reinit
 
           u = User.new({first_name: "John"})
-          post = Post.new({user: u, title: "some post" })
+          post = Post.new({user: u, title: "some post"})
 
           u.save!
           post.save! # Exception
@@ -841,6 +860,32 @@ module ModelSpec
           users = User.query.where { last_name == "smith" }.paginate(page: 1, per_page: 5)
           users.map(&.first_name).should eq ["user0", "user2", "user4", "user6", "user8"]
           users.total_entries.should eq 8
+        end
+      end
+    end
+  end
+
+  describe "BigDecimal / Numeric column in Migration" do
+    it "should create a new model with BigDecimal fields" do
+      temporary do
+        reinit
+
+        data = Data.new({num1: 42.0123, num2: "42_42_42_24.0123_456_789", num3: "-102938719.2083710928371092837019283701982370918237"})
+        data.num1.should eq(BigDecimal.new(BigInt.new(420123), 4))
+        data.num2.should eq(BigDecimal.new(BigInt.new(424242240123456789), 10))
+        data.num3.should eq(BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 40))
+
+        data.save!
+
+        data.num1.should eq(BigDecimal.new(BigInt.new(420123), 4))
+        data.num2.should eq(42424224.01234568)
+        data.num3.should eq(BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 40).trunc)
+
+        # Clear::SQL::Error:numeric field overflow
+        data.num4 = BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 40)
+
+        expect_raises(Clear::SQL::Error) do
+          data.save!
         end
       end
     end

--- a/src/clear/migration/migration.cr
+++ b/src/clear/migration/migration.cr
@@ -70,10 +70,11 @@ module Clear::Migration
   module Helper
     TYPE_MAPPING = {
       "string" => "text",
-      "int32" => "int",
+      "int32"  => "int",
 
-      "int64" => "bigint",
-      "long" => "bigint",
+      "int64"      => "bigint",
+      "long"       => "bigint",
+      "bigdecimal" => "numeric",
 
       "datetime" => "timestamp without time zone",
     }
@@ -103,38 +104,35 @@ module Clear::Migration
 
     # This will apply the migration in a given direction (up or down)
     def apply(dir : Direction)
-    Clear::Migration::Manager.instance.ensure_ready
+      Clear::Migration::Manager.instance.ensure_ready
 
-    Clear::SQL.transaction do
-      Log.info { "[#{dir}] #{self.class.name}" }
+      Clear::SQL.transaction do
+        Log.info { "[#{dir}] #{self.class.name}" }
 
-      change(dir)
+        change(dir)
 
-      dir.up do
-        @operations.each { |op|
-          op.up.each { |x| Clear::SQL.execute(x.as(String)) }
-        }
+        dir.up do
+          @operations.each { |op|
+            op.up.each { |x| Clear::SQL.execute(x.as(String)) }
+          }
 
-        SQL.insert("__clear_metadatas", {metatype: "migration", value: uid.to_s}).execute
+          SQL.insert("__clear_metadatas", {metatype: "migration", value: uid.to_s}).execute
+        end
+
+        dir.down do
+          @operations.reverse_each { |op|
+            op.down.each { |x| Clear::SQL.execute(x.as(String)) }
+          }
+
+          SQL.delete("__clear_metadatas").where({metatype: "migration", value: uid.to_s}).execute
+        end
+
+        self
       end
-
-      dir.down do
-        @operations.reverse_each { |op|
-          op.down.each { |x| Clear::SQL.execute(x.as(String)) }
-        }
-
-        SQL.delete("__clear_metadatas").where({metatype: "migration", value: uid.to_s}).execute
-      end
-
-      self
     end
-
-  end
-
   end
 
   include Helper
-
 
   macro included
 

--- a/src/clear/migration/operation/table.cr
+++ b/src/clear/migration/operation/table.cr
@@ -95,20 +95,20 @@ module Clear::Migration
       content = "(#{columns_and_fkeys.join(", ")})" unless columns_and_fkeys.empty?
 
       arr = if is_create?
-        [
-          ["CREATE TABLE", @name, content].compact.join(" "),
-        ]
-      else
-        # To implement later
-        [] of String
-      end
+              [
+                ["CREATE TABLE", @name, content].compact.join(" "),
+              ]
+            else
+              # To implement later
+              [] of String
+            end
 
       arr + print_indexes
     end
 
     def down : Array(String)
       [
-        (["DROP TABLE", @name].join(" ") if is_create?)
+        (["DROP TABLE", @name].join(" ") if is_create?),
       ].compact
     end
 
@@ -157,24 +157,25 @@ module Clear::Migration
     # column type (ActiveRecord's style)
     macro method_missing(caller)
       {% raise "Migration: usage of Table##{caller.name} is deprecated.\n" +
-                "Tip: use instead `self.column(NAME, \"#{caller.name}\", ...)`" %}
+               "Tip: use instead `self.column(NAME, \"#{caller.name}\", ...)`" %}
     end
 
     def column(name, type, default = nil, null = true, primary = false,
-      index = false, unique = false, array = false )
-
+               index = false, unique = false, array = false)
       type = case type.to_s
-      when "string"
-        "text"
-      when "int32", "integer"
-        "integer"
-      when "int64", "long"
-        "bigint"
-      when "datetime"
-        "timestamp without time zone"
-      else
-        type.to_s
-      end
+             when "string"
+               "text"
+             when "int32", "integer"
+               "integer"
+             when "int64", "long"
+               "bigint"
+             when "bigdecimal", "numeric"
+               "numeric"
+             when "datetime"
+               "timestamp without time zone"
+             else
+               type.to_s
+             end
 
       self.add_column(name.to_s, type: type, default: default, null: null,
         primary: primary, index: index, unique: unique, array: array)
@@ -185,7 +186,6 @@ module Clear::Migration
     @table : String
 
     def initialize(@table)
-
     end
 
     def up : Array(String)
@@ -254,7 +254,7 @@ module Clear::Migration
       when false
       else
         raise "Unknown key type while try to create new table: `#{id}`. Candidates are :bigserial, :serial and :uuid" +
-          "Please proceed with `id: false` and add the column manually"
+              "Please proceed with `id: false` and add the column manually"
       end
 
       yield(table)

--- a/src/clear/model/collection.cr
+++ b/src/clear/model/collection.cr
@@ -91,7 +91,7 @@ require "../sql/select_query"
 # By default, Clear map theses columns types:
 #
 # - `String` => `text`
-# - `Numbers` (any from 8 to 64 bits, float, double, big number, big float, numeric(arbitrary precision number)) => `int, large int etc... (depends of your choice)`
+# - `Numbers` (any from 8 to 64 bits, float, double, big number, big float, big decimal) => `int, large int, numeric(arbitrary precision number) etc... (depends of your choice)`
 # - `Bool` => `text or bool`
 # - `Time` => `timestamp without timezone or text`
 # - `JSON::Any` => `json and jsonb`

--- a/src/clear/model/collection.cr
+++ b/src/clear/model/collection.cr
@@ -16,9 +16,9 @@ require "../sql/select_query"
 # Now, you can play with your model:
 #
 # ```crystal
-#   row = MyModel.new # create an empty row
-#   row.my_column = "This is a content"
-#   row.save! # insert the new row in the database !
+# row = MyModel.new # create an empty row
+# row.my_column = "This is a content"
+# row.save! # insert the new row in the database !
 # ```
 #
 # By convention, the table name will follow an underscore, plural version of your model: `my_models`.
@@ -43,8 +43,8 @@ require "../sql/select_query"
 # For example, this code will compile:
 #
 # ```crystal
-#   row = MyModel.new # create an empty row
-#   puts row.my_column
+# row = MyModel.new # create an empty row
+# puts row.my_column
 # ```
 #
 # However, it will throw a runtime exception `You cannot access to the field 'my_column' because it never has been initialized`
@@ -52,8 +52,8 @@ require "../sql/select_query"
 # Same way, trying to save the object will raise an error:
 #
 # ```crystal
-#   row.save # Will return false
-#   pp row.errors # Will tell you than `my_column` presence is mandatory.
+# row.save      # Will return false
+# pp row.errors # Will tell you than `my_column` presence is mandatory.
 # ```
 #
 # Thanks to expressiveness of the Crystal language, we can handle presence validation by simply using the `Nilable` type in crystal:
@@ -91,7 +91,7 @@ require "../sql/select_query"
 # By default, Clear map theses columns types:
 #
 # - `String` => `text`
-# - `Numbers` (any from 8 to 64 bits, float, double, big number, big float) => `int, large int etc... (depends of your choice)`
+# - `Numbers` (any from 8 to 64 bits, float, double, big number, big float, numeric(arbitrary precision number)) => `int, large int etc... (depends of your choice)`
 # - `Bool` => `text or bool`
 # - `Time` => `timestamp without timezone or text`
 # - `JSON::Any` => `json and jsonb`
@@ -137,7 +137,7 @@ require "../sql/select_query"
 # ```crystal
 # class MyModel
 #   include Clear::Model
-#   timestamps #Will map the two columns 'created_at' and 'updated_at', and map some hooks to update their values.
+#   timestamps # Will map the two columns 'created_at' and 'updated_at', and map some hooks to update their values.
 # end
 # ```
 #
@@ -156,7 +156,6 @@ require "../sql/select_query"
 #
 # Argument is optional (default = id)
 module Clear::Model
-
   # `CollectionBase(T)` is the base class for collection of model.
   # Collection of model are a SQL `SELECT` query mapping & building system. They are Enumerable and are
   # `Clear::SQL::SelectBuilder` behavior; therefore, they can be used array-like and are working with low-level SQL
@@ -214,7 +213,7 @@ module Clear::Model
       @before_query_triggers = [] of -> Void,
       @tags = {} of String => Clear::SQL::Any,
       @cache = Clear::Model::QueryCache.new,
-      @cached_result = nil,
+      @cached_result = nil
     )
     end
 
@@ -237,7 +236,6 @@ module Clear::Model
       T
     end
 
-
     # :nodoc:
     # Set a query cache on this Collection. Fetching and enumerate will use the cache instead of calling the SQL.
     def cached(cache : Clear::Model::QueryCache)
@@ -256,7 +254,7 @@ module Clear::Model
     def flag_as_polymorphic!(@polymorphic_key, scope : Enumerable(String))
       @polymorphic = true
       polymorphic_scope = @polymorphic_scope = Set(String).new
-      scope.each{ |x| polymorphic_scope.add(x) }
+      scope.each { |x| polymorphic_scope.add(x) }
 
       self
     end

--- a/src/clear/model/converters/number_converters.cr
+++ b/src/clear/model/converters/number_converters.cr
@@ -40,4 +40,5 @@ module Clear::Model::Converter
 
   number_converter(BigInt)
   number_converter(BigFloat)
+  number_converter(BigDecimal)
 end

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -49,7 +49,7 @@ module Clear
                 Array(PG::Float64Array) | Array(PG::Int16Array) | Array(PG::Int32Array) |
                 Array(PG::Int64Array) | Array(PG::StringArray) | Array(PG::TimeArray) |
                 Array(PG::NumericArray) |
-                Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | JSON::Any | JSON::Any::Type | PG::Geo::Box | PG::Geo::Circle |
+                Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | BigDecimal | JSON::Any | JSON::Any::Type | PG::Geo::Box | PG::Geo::Circle |
                 PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point |
                 PG::Geo::Polygon | PG::Numeric | Slice(UInt8) | String | Time |
                 UInt8 | UInt16 | UInt32 | UInt64 | Clear::Expression::UnsafeSql |
@@ -69,8 +69,8 @@ module Clear
     # This provide a fast way to create SQL fragment while escaping items, both with `?` and `:key` system:
     #
     # ```
-    # query = Mode.query.select( Clear::SQL.raw("CASE WHEN x=:x THEN 1 ELSE 0 END as check", x: "blabla") )
-    # query = Mode.query.select( Clear::SQL.raw("CASE WHEN x=? THEN 1 ELSE 0 END as check", "blabla") )
+    # query = Mode.query.select(Clear::SQL.raw("CASE WHEN x=:x THEN 1 ELSE 0 END as check", x: "blabla"))
+    # query = Mode.query.select(Clear::SQL.raw("CASE WHEN x=? THEN 1 ELSE 0 END as check", "blabla"))
     # ```
     def raw(x, *params)
       Clear::Expression.raw(x, *params)
@@ -81,7 +81,6 @@ module Clear
     def raw_enum(x, params : Enumerable(T)) forall T
       Clear::Expression.raw_enum(x, params)
     end
-
 
     def raw(__template, **params)
       Clear::Expression.raw(__template, **params)
@@ -109,7 +108,7 @@ module Clear
 
     def init(name : String, url : String, connection_pool_size = 5)
       Clear::SQL::ConnectionPool.init(url, name, connection_pool_size)
-      #@@connections[name] = DB.open(url)
+      # @@connections[name] = DB.open(url)
     end
 
     def init(connections : Hash(Symbolic, String), connection_pool_size = 5)
@@ -159,7 +158,6 @@ module Clear
           end
         end
       end
-
     end
 
     # Create a transaction, but this one is stackable
@@ -187,13 +185,12 @@ module Clear
       end
     end
 
-
     # Truncate a table or a model
     #
     # ```
-    #   User.query.count # => 200
-    #   Clear::SQL.truncate(User) # equivalent to Clear::SQL.truncate(User.table, connection_name: User.connection)
-    #   User.query.count # => 0
+    # User.query.count          # => 200
+    # Clear::SQL.truncate(User) # equivalent to Clear::SQL.truncate(User.table, connection_name: User.connection)
+    # User.query.count          # => 0
     # ```
     #
     # SEE https://www.postgresql.org/docs/current/sql-truncate.html
@@ -204,7 +201,7 @@ module Clear
     # - `truncate_inherited` set to false will append `ONLY` to the query
     # - `connection_name` will be: `Model.connection` or `default` unless optionally defined.
     def self.truncate(tablename : T.class | String, restart_sequence = false, cascade = false, truncate_inherited = true, connection_name : String? = nil) forall T
-      if(tablename.is_a?(String))
+      if (tablename.is_a?(String))
         connection_name ||= "default"
       else
         connection_name ||= tablename.connection
@@ -216,7 +213,7 @@ module Clear
       cascade = cascade ? " CASCADE " : ""
 
       execute(connection_name,
-        {"TRUNCATE TABLE ", only, Clear::SQL.escape(tablename), restart_sequence, cascade }.join
+        {"TRUNCATE TABLE ", only, Clear::SQL.escape(tablename), restart_sequence, cascade}.join
       )
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add `[BigDecimal](https://crystal-lang.org/api/0.35.1/BigDecimal.html)` converter.
- Allow `[Numeric](https://www.postgresql.org/docs/9.6/datatype-numeric.html) (Arbitrary Precision Numbers)` type in migration (e.g. `numeric`, `numeric(10)`, `numeric(10, 5)`)
- Map `BigDecimal` (in `.cr`) to `Numeric` (in `pg`) in migration columns (i.e. declaring column data type as `"bigdecimal"` would be equal to the column being declared with type `"numeric"`, if you wish to specify precision, and scale, please use `"numeric(precision, scale)"` or `"numeric(precision)"` (with scale defaulting to 0), instead of `"bigdecimal"`)

- For usage of `BigDecimal`, please consult Crystal docs as specified in the first bullet point.
- For usage of `Numeric`, please consult PostgreSQL docs as specified in the second bullet point.
- All usage example is available inside the spec files as listed in the section below.
- Please also take note that PostgreSQL will throw a `numeric field overflow` (and in Clear: `Clear::SQl::Error`) if you `INSERT` into the database a BigDecimal/ numeric value with the integer part (to the left of the radix point) of a size that is bigger than the precision that is specified in the numeric type that you declare. This can be seen from the following example taken from specs:

```

  class Data
    include Clear::Model

    column id : Int32, primary: true, presence: false
    column num3 : BigDecimal?
    column num4 : BigDecimal?
  end

  class ModelSpecMigration123
    include Clear::Migration

    def change(dir)
      create_table(:model_spec_data) do |t|
        t.column "num3", "numeric(9)"
        t.column "num4", "numeric(8)"
      end
    end
end

data = Data.new
big_number = BigDecimal.new(BigInt.new("-1029387192083710928371092837019283701982370918237".to_big_i), 40) # this is the same as "-102938719.2083710928371092837019283701982370918237"
```

The following case would not throw an error
```
data.num3 = big_number
data.save!
```

However this case would throw an error
```
data.num4 = big_number
data.save!
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Allow usage of `BigDecimal` in model, `Numeric` in database, and the mapping of the two, especially for financial data.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- `BigDecimal` converter spec has been written and passes smoothly at the following path `clear/spec/model/converter_spec.cr`
- `Numeric` in migration columns has been added to the following spec file `clear/spec/model/model_spec.cr`, which passes smoothly.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [x] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
